### PR TITLE
fix(proxy): Correctly parse legacy_session_id in TLS ClientHello

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -191,7 +191,8 @@ func getSNI(reader io.Reader) (string, []byte, error) {
 	}
 
 	// Skip legacy session id.
-	if !clientHello.Skip(1) {
+	var legacySessionID cryptobyte.String
+	if !clientHello.ReadUint8LengthPrefixed(&legacySessionID) {
 		return "", nil, errors.New("error parsing session id")
 	}
 


### PR DESCRIPTION
The previous implementation of the `getSNI` function incorrectly skipped the `legacy_session_id` field in the TLS ClientHello message. It used `clientHello.Skip(1)`, which only skipped the 1-byte length prefix of the session ID, but not the session ID itself.

This caused the parser to be misaligned, leading to a failure when attempting to parse the subsequent `cipher_suites` field, resulting in an "error parsing cipher suites" error and causing the connection to be dropped.

This commit fixes the issue by replacing `clientHello.Skip(1)` with `clientHello.ReadUint8LengthPrefixed(&legacySessionID)`. This correctly reads the length-prefixed session ID, advancing the parser correctly and allowing the rest of the ClientHello message to be parsed successfully.