### PR TITLE
feat: Add proxy stealth mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,22 +15,25 @@ const (
 	StealthNone   StealthMode = "none"
 	StealthNginx  StealthMode = "nginx"
 	StealthApache StealthMode = "apache"
+	StealthProxy  StealthMode = "proxy"
 )
 
 // Config stores all configuration parameters.
 type Config struct {
 	Domain      string
 	StealthMode StealthMode
+	ProxyURL    string
 }
 
 // New creates a new configuration by reading flags and environment variables.
 func New() *Config {
 	cfg := &Config{}
 
-	var domain, stealthMode string
+	var domain, stealthMode, proxyURL string
 
 	flag.StringVar(&domain, "domain", "", "Domain for the TLS certificate (required).")
-	flag.StringVar(&stealthMode, "stealth-mode", "nginx", "Stealth mode: 'none', 'nginx', or 'apache'.")
+	flag.StringVar(&stealthMode, "stealth-mode", "nginx", "Stealth mode: 'none', 'nginx', 'apache', or 'proxy'.")
+	flag.StringVar(&proxyURL, "proxy-url", "", "Proxy URL for 'proxy' stealth mode.")
 	flag.Parse()
 
 	if domain == "" {
@@ -39,21 +42,30 @@ func New() *Config {
 	if stealthMode == "" || stealthMode == "nginx" && os.Getenv("STEALTH_MODE") != "" {
 		stealthMode = os.Getenv("STEALTH_MODE")
 	}
+	if proxyURL == "" {
+		proxyURL = os.Getenv("PROXY_URL")
+	}
 
 	if domain == "" {
 		log.Fatal("Domain is required. Set it with -domain flag or DOMAIN environment variable.")
 	}
 	cfg.Domain = domain
+	cfg.ProxyURL = proxyURL
 
 	switch strings.ToLower(stealthMode) {
 	case "nginx":
 		cfg.StealthMode = StealthNginx
 	case "apache":
 		cfg.StealthMode = StealthApache
+	case "proxy":
+		cfg.StealthMode = StealthProxy
+		if proxyURL == "" {
+			log.Fatal("Proxy URL is required for 'proxy' stealth mode. Set it with -proxy-url or PROXY_URL.")
+		}
 	case "none":
 		cfg.StealthMode = StealthNone
 	default:
-		log.Fatalf("Invalid stealth mode: %s. Use 'none', 'nginx', or 'apache'.", stealthMode)
+		log.Fatalf("Invalid stealth mode: %s. Use 'none', 'nginx', 'apache', or 'proxy'.", stealthMode)
 	}
 
 	return cfg

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -134,6 +134,10 @@ func handleStealth(conn net.Conn, cfg *config.Config) {
 	case config.StealthApache:
 		log.Printf("Stealth mode: Serving full fake Apache page to %s", conn.RemoteAddr())
 		response = stealth.GetApacheResponse()
+	case config.StealthProxy:
+		log.Printf("Stealth mode: Proxying to %s for %s", cfg.ProxyURL, conn.RemoteAddr())
+		stealth.ProxyRequest(conn, cfg.ProxyURL)
+		return
 	case config.StealthNone:
 		// In "none" mode, just close the connection.
 		return

--- a/internal/stealth/proxy.go
+++ b/internal/stealth/proxy.go
@@ -1,0 +1,78 @@
+package stealth
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+// ProxyRequest forwards the client's request to a specified proxy URL and streams the response.
+func ProxyRequest(clientConn net.Conn, proxyURL string) {
+	// Ensure the client connection is closed when the function exits.
+	defer clientConn.Close()
+
+	// Parse the provided proxy URL to extract the host.
+	parsedURL, err := url.Parse(proxyURL)
+	if err != nil {
+		log.Printf("Error parsing proxy URL '%s': %v", proxyURL, err)
+		return
+	}
+	host := parsedURL.Host
+	if parsedURL.Port() == "" {
+		host = net.JoinHostPort(host, "443")
+	}
+
+	// Establish a connection to the proxy destination.
+	destConn, err := net.Dial("tcp", host)
+	if err != nil {
+		log.Printf("Error connecting to proxy host '%s': %v", host, err)
+		return
+	}
+	defer destConn.Close()
+
+	// Read the full initial request from the client.
+	clientReader := bufio.NewReader(clientConn)
+	req, err := http.ReadRequest(clientReader)
+	if err != nil {
+		log.Printf("Error reading request from client: %v", err)
+		return
+	}
+
+	// Forward the initial request to the destination server.
+	if err := req.Write(destConn); err != nil {
+		log.Printf("Error writing request to destination: %v", err)
+		return
+	}
+
+	log.Printf("Proxying request to %s", host)
+
+	// Use a WaitGroup to wait for both directions of the proxy to complete.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine to copy data from the client to the destination.
+	go func() {
+		defer wg.Done()
+		io.Copy(destConn, clientConn)
+		if tcpConn, ok := destConn.(*net.TCPConn); ok {
+			tcpConn.CloseWrite()
+		}
+	}()
+
+	// Goroutine to copy data from the destination back to the client.
+	go func() {
+		defer wg.Done()
+		io.Copy(clientConn, destConn)
+		if tcpConn, ok := clientConn.(*net.TCPConn); ok {
+			tcpConn.CloseWrite()
+		}
+	}()
+
+	// Wait for both copy operations to finish.
+	wg.Wait()
+	log.Printf("Proxy connection to %s closed", host)
+}

--- a/internal/stealth/proxy_test.go
+++ b/internal/stealth/proxy_test.go
@@ -1,0 +1,95 @@
+package stealth
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProxyRequest(t *testing.T) {
+	// 1. Create a mock destination server
+	destListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to create destination listener: %v", err)
+	}
+	defer destListener.Close()
+	destAddr := destListener.Addr().String()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		destConn, err := destListener.Accept()
+		if err != nil {
+			t.Errorf("Destination failed to accept connection: %v", err)
+			return
+		}
+		defer destConn.Close()
+
+		// Read the request from the proxy
+		_, err = http.ReadRequest(bufio.NewReader(destConn))
+		if err != nil {
+			t.Errorf("Destination failed to read request: %v", err)
+			return
+		}
+
+		// Write a response
+		response := "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\nHello, World"
+		if _, err := destConn.Write([]byte(response)); err != nil {
+			t.Errorf("Destination failed to write response: %v", err)
+		}
+	}()
+
+	// 2. Create a mock client listener
+	clientListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to create client listener: %v", err)
+	}
+	defer clientListener.Close()
+	clientAddr := clientListener.Addr().String()
+
+	// 3. Run ProxyRequest in a goroutine
+	go func() {
+		clientConn, err := clientListener.Accept()
+		if err != nil {
+			t.Errorf("Proxy failed to accept client connection: %v", err)
+			return
+		}
+		ProxyRequest(clientConn, fmt.Sprintf("http://%s", destAddr))
+	}()
+
+	// 4. Mock client connects to the proxy
+	proxyConn, err := net.Dial("tcp", clientAddr)
+	if err != nil {
+		t.Fatalf("Client failed to connect to proxy: %v", err)
+	}
+	defer proxyConn.Close()
+
+	// 5. Send a request from the client to the proxy
+	request := "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	if _, err := proxyConn.Write([]byte(request)); err != nil {
+		t.Fatalf("Client failed to write request: %v", err)
+	}
+
+	// 6. Read the response from the proxy
+	proxyConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	response, err := ioutil.ReadAll(proxyConn)
+	if err != nil {
+		t.Fatalf("Client failed to read response: %v", err)
+	}
+
+	// 7. Verify the response
+	expectedResponse := "Hello, World"
+	if !strings.Contains(string(response), expectedResponse) {
+		t.Errorf("Expected response to contain '%s', but got '%s'", expectedResponse, string(response))
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This commit introduces a new 'proxy' stealth mode. When this mode is enabled, the application will act as a simple TLS proxy, forwarding all non-Signal traffic to a user-configured URL. This provides a more convincing camouflage than the static Nginx/Apache pages, as it can point to a live, legitimate website.

A new configuration option, `-proxy-url` (and `PROXY_URL` environment variable), has been added to specify the target URL for proxying.

The implementation includes:
- A new `ProxyRequest` function in `internal/stealth/proxy.go` to handle the proxying logic.
- Updates to the configuration handling to support the new mode and URL.
- Integration into the main handler to activate the proxy mode.
- A new unit test to validate the proxy functionality.