### PR TITLE
fix: Final fix for proxy stealth mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"flag"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -61,6 +62,13 @@ func New() *Config {
 		cfg.StealthMode = StealthProxy
 		if proxyURL == "" {
 			log.Fatal("Proxy URL is required for 'proxy' stealth mode. Set it with -proxy-url or PROXY_URL.")
+		}
+		u, err := url.Parse(proxyURL)
+		if err != nil {
+			log.Fatalf("Invalid proxy URL: %v", err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			log.Fatal("Proxy URL must have a scheme of 'http' or 'https'.")
 		}
 	case "none":
 		cfg.StealthMode = StealthNone

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -61,7 +61,7 @@ func HandleConnection(conn net.Conn, cfg *config.Config) {
 	case ProtoSignalTLS:
 		handleSignalProxy(bufReader, conn)
 	case ProtoHTTP:
-		handleStealth(conn, cfg)
+		handleStealth(bufReader, conn, cfg)
 	default:
 		log.Printf("Unknown protocol from %s, closing connection.", conn.RemoteAddr())
 	}
@@ -124,7 +124,7 @@ func handleSignalProxy(reader io.Reader, clientConn net.Conn) {
 }
 
 // handleStealth responds to HTTP requests with a stealth page to provide camouflage.
-func handleStealth(conn net.Conn, cfg *config.Config) {
+func handleStealth(clientReader *bufio.Reader, conn net.Conn, cfg *config.Config) {
 	var response []byte
 
 	switch cfg.StealthMode {
@@ -136,7 +136,7 @@ func handleStealth(conn net.Conn, cfg *config.Config) {
 		response = stealth.GetApacheResponse()
 	case config.StealthProxy:
 		log.Printf("Stealth mode: Proxying to %s for %s", cfg.ProxyURL, conn.RemoteAddr())
-		stealth.ProxyRequest(conn, cfg.ProxyURL)
+		stealth.ProxyRequest(clientReader, conn, cfg.ProxyURL)
 		return
 	case config.StealthNone:
 		// In "none" mode, just close the connection.

--- a/internal/stealth/proxy.go
+++ b/internal/stealth/proxy.go
@@ -10,11 +10,10 @@ import (
 )
 
 // ProxyRequest forwards the client's request to a specified proxy URL and streams the response.
-func ProxyRequest(clientConn net.Conn, proxyURL string) {
+func ProxyRequest(clientReader *bufio.Reader, clientConn net.Conn, proxyURL string) {
 	defer clientConn.Close()
 
 	// Read the full initial request from the client.
-	clientReader := bufio.NewReader(clientConn)
 	req, err := http.ReadRequest(clientReader)
 	if err != nil {
 		// This can happen if the client disconnects, it's not always a server error.

--- a/internal/stealth/proxy_test.go
+++ b/internal/stealth/proxy_test.go
@@ -27,7 +27,7 @@ func TestProxyRequest(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ProxyRequest(serverConn, mockDestServer.URL)
+		ProxyRequest(bufio.NewReader(serverConn), serverConn, mockDestServer.URL)
 	}()
 
 	// 4. Write a sample HTTP request to the client side of the pipe


### PR DESCRIPTION
This commit resolves two critical bugs in the proxy stealth mode:
1.  **Fixes hanging connections:** The previous code failed to pass the buffered reader (used for protocol sniffing) to the proxy handler. This resulted in a broken stream, causing `http.ReadRequest` to hang indefinitely. The fix ensures the `bufio.Reader` is passed down the entire call stack, providing the proxy handler with the complete, unaltered client request.

2.  **Adds URL validation:** The `-proxy-url` parameter now undergoes validation at startup to ensure it is a valid URL with an `http` or `https` scheme. This prevents runtime errors that would occur from using a scheme-less or malformed URL.

The unit tests have also been updated to reflect these changes. The proxy mode should now be stable and functional.